### PR TITLE
[fix] replace tei-completer jar link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # TEI Completer
-[![Build Status](https://travis-ci.org/BCDH/TEI-Completer.png?branch=master)](https://travis-ci.org/BCDH/TEI-Completer) [![Java 8+](https://img.shields.io/badge/java-8+-4c7e9f.svg)](http://java.oracle.com) [![License GPL 2](https://img.shields.io/badge/license-GPL%202-blue.svg)](https://www.gnu.org/licenses/gpl-2.0.html) [![Download](https://img.shields.io/badge/download-version%201.2.0-ff69b4.svg)](http://search.maven.org/remotecontent?filepath=org/humanistika/oxygen/tei-completer/1.2.0/tei-completer-1.2.0-oxygen-plugin.jar)
+[![Build Status](https://travis-ci.org/BCDH/TEI-Completer.png?branch=master)](https://travis-ci.org/BCDH/TEI-Completer) [![Java 8+](https://img.shields.io/badge/java-8+-4c7e9f.svg)](http://java.oracle.com) [![License GPL 2](https://img.shields.io/badge/license-GPL%202-blue.svg)](https://www.gnu.org/licenses/gpl-2.0.html) [![Download](https://img.shields.io/badge/download-version%201.2.0-ff69b4.svg)](https://repo1.maven.org/maven2/org/humanistika/oxygen/tei-completer/1.2.0/tei-completer-1.2.0-oxygen-plugin.jar)
 
 The TEI Completer is a highly customizable plugin for setting up and activating remote-driven autocompletions of attribute values in the [oXygen XML Editor](http://www.oxygenxml.com).  
 
@@ -24,7 +24,7 @@ The plugin has been developed at the [Belgrade Center for Digital Humanities](ht
 
 # Installation
 
-1. Download the precompiled binary of the TEI Completer from [here](http://search.maven.org/remotecontent?filepath=org/humanistika/oxygen/tei-completer/1.2.0/tei-completer-1.2.0-oxygen-plugin.jar) or [build from source](#building).
+1. Download the precompiled binary of the TEI Completer from [here](https://repo1.maven.org/maven2/org/humanistika/oxygen/tei-completer/1.2.0/tei-completer-1.2.0-oxygen-plugin.jar) or [build from source](#building).
 
 2. Copy the file `tei-completer-1.2.0-oxygen-plugin.jar` to `$OXYGEN_HOME/frameworks/tei`.
 


### PR DESCRIPTION
The precompiled binary link of the TEI Completer: http://search.maven.org/remotecontent?filepath=org/humanistika/oxygen/tei-completer/1.2.0/tei-completer-1.2.0-oxygen-plugin.jar
is no longer working.
This PR will change the link to https://repo1.maven.org/maven2/org/humanistika/oxygen/tei-completer/1.2.0/tei-completer-1.2.0.jar.