### PR TITLE
[fix] force utf-8 encoding in windows

### DIFF
--- a/src/main/java/org/humanistika/oxygen/tei/completer/response/impl/JSONTransformer.java
+++ b/src/main/java/org/humanistika/oxygen/tei/completer/response/impl/JSONTransformer.java
@@ -87,7 +87,7 @@ public class JSONTransformer implements Transformer {
                 final char buf[] = new char[4096];
                 int read = -1;
                 try(final Reader jsonReader = new StringReader(jsonResult);
-                    final Writer writer = new OutputStreamWriter(result)) {
+                    final Writer writer = new OutputStreamWriter(result, UTF_8)) {
                     while((read = jsonReader.read(buf)) > -1) {
                         writer.write(buf, 0, read);
                     }


### PR DESCRIPTION
On windows the response was not shown correctly as seen in this image
![image](https://github.com/BCDH/TEI-Completer/assets/30597211/ee0e634d-a160-476d-9306-bfa591d5876c)

this PR fixes the encoding issue