### PR TITLE
[fix] always show the custom lookup

### DIFF
--- a/src/main/java/org/humanistika/oxygen/tei/completer/TeiCompleter.java
+++ b/src/main/java/org/humanistika/oxygen/tei/completer/TeiCompleter.java
@@ -93,7 +93,7 @@ public class TeiCompleter implements SchemaManagerFilter {
             if(autoCompleteSuggestions != null) {
                 list.addAll(autoCompleteSuggestions.getSuggestions());
             }
-            if(autoCompleteSuggestions != null && autoCompleteSuggestions.getSuggestions().size() == 0) {
+            if(autoCompleteSuggestions != null) {
                 // the value needs to be prefixed with a space character to bump it to the top of the list
                 list.add(new CustomCIValue(" Custom lookup...", this, autoCompleteSuggestions.autoCompleteContext));
             }

--- a/src/main/java/org/humanistika/oxygen/tei/completer/TeiCompleter.java
+++ b/src/main/java/org/humanistika/oxygen/tei/completer/TeiCompleter.java
@@ -55,6 +55,7 @@ import static org.humanistika.oxygen.tei.completer.XPathUtil.parseXPath;
 
 import java.awt.*;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * TEI-Completer
@@ -90,12 +91,19 @@ public class TeiCompleter implements SchemaManagerFilter {
     public List<CIValue> filterAttributeValues(final List<CIValue> list, final WhatPossibleValuesHasAttributeContext context) {
         if (context != null) {
             final AutoCompleteSuggestions<AutoComplete> autoCompleteSuggestions = getAutoCompleteSuggestions(context);
+
             if(autoCompleteSuggestions != null) {
-                list.addAll(autoCompleteSuggestions.getSuggestions());
+                List<CIValue> spacePrefixedList = autoCompleteSuggestions.getSuggestions().stream().map(ciValue -> {
+                    ciValue.setValue(" " + ciValue.getValue());
+                    return ciValue;
+                }).collect(Collectors.toList());
+
+                list.addAll(spacePrefixedList);
             }
+
             if(autoCompleteSuggestions != null) {
                 // the value needs to be prefixed with a space character to bump it to the top of the list
-                list.add(new CustomCIValue(" Custom lookup...", this, autoCompleteSuggestions.autoCompleteContext));
+                list.add(new CustomCIValue("\uD83D\uDC49 Custom lookup...", this, autoCompleteSuggestions.autoCompleteContext));
             }
 
         }


### PR DESCRIPTION
Fixes #14 
The Custom Look Up will always be shown on top even when we have matches results
<img width="313" alt="always-show" src="https://github.com/BCDH/TEI-Completer/assets/30597211/5aa5de37-564a-4c0f-b2b7-18d1bc67d1ba">
