### PR TITLE
[fix] rename the field to custom lookup

### DIFF
--- a/src/main/java/org/humanistika/oxygen/tei/completer/TeiCompleter.java
+++ b/src/main/java/org/humanistika/oxygen/tei/completer/TeiCompleter.java
@@ -95,7 +95,7 @@ public class TeiCompleter implements SchemaManagerFilter {
             }
             if(autoCompleteSuggestions != null && autoCompleteSuggestions.getSuggestions().size() == 0) {
                 // the value needs to be prefixed with a space character to bump it to the top of the list
-                list.add(new CustomCIValue(" Custom Entry...", this, autoCompleteSuggestions.autoCompleteContext));
+                list.add(new CustomCIValue(" Custom lookup...", this, autoCompleteSuggestions.autoCompleteContext));
             }
 
         }


### PR DESCRIPTION
Fixes #15 
The auto complete popup will now say "Custom lookup..."
<img width="351" alt="custom lookup" src="https://github.com/BCDH/TEI-Completer/assets/30597211/688a3dfb-0926-4066-a881-59103e9f6b8b">
