### PR TITLE
Bump xpath-parser dependency to pass tests on Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>com.evolvedbinary.xpath</groupId>
             <artifactId>xpath2-parser</artifactId>
-            <version>1.0</version>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>jakarta.xml.bind</groupId>


### PR DESCRIPTION
The Java 17 build should be passing now
@adamretter after you merge this i will update the readme to disclose that we no longer support java 8