### PR TITLE
Remove Java 8, and update for compatibility with Java 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        jdk: [8,11,17]
+        jdk: [11,17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # TEI Completer
-[![Build Status](https://github.com/BCDH/TEI-Completer/actions/workflows/ci.yml/badge.svg)](https://github.com/BCDH/TEI-Completer/actions/workflows/ci.yml) [![Java 8+](https://img.shields.io/badge/java-8+-4c7e9f.svg)](http://java.oracle.com) [![License GPL 2](https://img.shields.io/badge/license-GPL%202-blue.svg)](https://www.gnu.org/licenses/gpl-2.0.html) [![Download](https://img.shields.io/badge/download-version%201.2.0-ff69b4.svg)](https://repo1.maven.org/maven2/org/humanistika/oxygen/tei-completer/1.2.0/tei-completer-1.2.0-oxygen-plugin.jar)
+[![Build Status](https://github.com/BCDH/TEI-Completer/actions/workflows/ci.yml/badge.svg)](https://github.com/BCDH/TEI-Completer/actions/workflows/ci.yml) [![Java 11+](https://img.shields.io/badge/java-11+-4c7e9f.svg)](http://java.oracle.com) [![License GPL 2](https://img.shields.io/badge/license-GPL%202-blue.svg)](https://www.gnu.org/licenses/gpl-2.0.html) [![Download](https://img.shields.io/badge/download-version%201.2.0-ff69b4.svg)](https://repo1.maven.org/maven2/org/humanistika/oxygen/tei-completer/1.2.0/tei-completer-1.2.0-oxygen-plugin.jar)
 
 The TEI Completer is a highly customizable plugin for setting up and activating remote-driven autocompletions of attribute values in the [oXygen XML Editor](http://www.oxygenxml.com).  
 
@@ -225,7 +225,7 @@ function transform(content) {
 
 # <a name="building"></a> Building from Source Code
 
-* Requirements: Git, Apache Maven 3, Java JDK 8
+* Requirements: Git, Apache Maven 3, Java JDK 11
 
 ```bash
 $ git clone https://github.com/BCDH/TEI-Completer.git

--- a/pom.xml
+++ b/pom.xml
@@ -50,10 +50,10 @@
         <jaxb2-basics.version>0.13.1</jaxb2-basics.version>
         <eclipse.persistence.version>2.7.10</eclipse.persistence.version>
         <junit.jupiter.version>5.9.3</junit.jupiter.version>
-        <project.build.source>1.8</project.build.source>
-        <project.build.target>1.8</project.build.target>
+        <project.build.source>11</project.build.source>
+        <project.build.target>11</project.build.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <enforce.release.jdk-version>(1.8.0,1.9.0)</enforce.release.jdk-version>
+        <enforce.release.jdk-version>(11,17)</enforce.release.jdk-version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>com.evolvedbinary.xpath</groupId>
             <artifactId>xpath2-parser</artifactId>
-            <version>1.0</version>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>jakarta.xml.bind</groupId>


### PR DESCRIPTION
It bumps the minimum Java version to 11, and removes support for Java 8. This is needed as the latest xpath2-parser dependency now requires Java 11+.